### PR TITLE
Add Missing Action: TradeWithBank

### DIFF
--- a/DefaultConfiguration.toml
+++ b/DefaultConfiguration.toml
@@ -29,3 +29,5 @@ RESOURCE = 25
 
 [PlayerSettings]
 USING_REAL_BOARD = false
+# Reset the `Player` struct after the game so they can be re-used.
+RESET_AFTER_GAME = true

--- a/src/Catan.jl
+++ b/src/Catan.jl
@@ -36,7 +36,7 @@ import .GameRunner
 
 include("../test/helper.jl")
 
-export HumanPlayer, DefaultRobotPlayer, RobotPlayer, Player, Board, Map, Road, PlayerType, PlayerPublicView, Game,
+export HumanPlayer, DefaultRobotPlayer, ChosenAction, RobotPlayer, Player, Board, Map, Road, PlayerType, PlayerPublicView, Game,
     initialize_and_do_game!,
 BoardApi, 
 PlayerApi,

--- a/src/actions.jl
+++ b/src/actions.jl
@@ -33,8 +33,8 @@ ACTIONS_DICTIONARY = Dict(
 
 
 function do_trade_with_bank(board, player, from::Symbol, to::Symbol)
-    if BoardApi.has_enough_resources(board, to)
-        PlayerApi.trade_resource_with_bank(player.player, card, from, to)
+    if BoardApi.can_draw_resource(board, to)
+        PlayerApi.trade_resource_with_bank(player.player, from, to)
     else
         @debug "Not enough resources to trade with bank (missing sufficient $to)"
     end
@@ -258,8 +258,8 @@ function get_legal_actions(game, board, player::Player)::Set{PreAction}
     if PlayerApi.has_any_resources(player)
         push!(actions, PreAction(:ProposeTrade))
     end
+    trade_args = Vector{Tuple}([])
     for from_resource = PlayerApi.resources_to_trade_with_bank(player)
-        trade_args = []
         for to_resource in RESOURCES
             if from_resource == to_resource || !BoardApi.can_draw_resource(board, to_resource)
                 continue

--- a/src/apis/player_api.jl
+++ b/src/apis/player_api.jl
@@ -144,7 +144,7 @@ function resources_to_trade_with_bank(player::Player)::Vector{Symbol}
     resources = Vector{Symbol}()
     for (r,amt) in player.resources
         if amt >= player.ports[r]
-            append!(resources, amt)
+            push!(resources, r)
         end
     end
     return resources

--- a/src/apis/player_api.jl
+++ b/src/apis/player_api.jl
@@ -140,6 +140,16 @@ function has_any_resources(player::PlayerPublicView)::Bool
     return player.resource_count > 0
 end
 
+function resources_to_trade_with_bank(player::Player)::Vector{Symbol}
+    resources = Vector{Symbol}()
+    for (r,amt) in player.resources
+        if amt >= player.ports[r]
+            append!(resources, amt)
+        end
+    end
+    return resources
+end
+
 function has_enough_resources(player::Player, resources::Dict{Symbol,TInt})::Bool where TInt <: Integer
     for (r,amt) in resources
         if !haskey(player.resources, r)

--- a/src/constants.jl
+++ b/src/constants.jl
@@ -158,12 +158,14 @@ const HUMAN_ACTIONS = Dict(
     "bc" => :ConstructCity,
     "br" => :ConstructRoad,
     "pt" => :ProposeTrade,
+    "tb" => :TradeWithBank,
     "bd" => :BuyDevCard,
     "pd" => :PlayDevCard,
     "e" => :DoNothing
    )
 const ACTION_TO_DESCRIPTION = Dict(
     :ProposeTrade => "[pt] Propose trade (e.g. \"pt 2 w w g g\")",
+    :TradeWithBank => "[tb] Trade with bank (e.g. \"tb w g\")",
     :ConstructCity => "[bc] Build city",
     :ConstructSettlement => "[bs] Build settlement",
     :ConstructRoad => "[br] Build road",

--- a/src/parsing.jl
+++ b/src/parsing.jl
@@ -101,6 +101,8 @@ function _parse_action(io, descriptor, configs::Dict)::ChosenAction
             return ChosenAction(func)
         elseif fname == "pd"
             return ChosenAction(func, (_parse_devcard_symbol(out_str[2], configs)))
+        elseif fname == "tb"
+            return ChosenAction(func, (_parse_devcard_symbol(out_str[1], configs), _parse_devcard_symbol(out_str[2], configs)))
         else
             return ChosenAction(func)
         end

--- a/src/players/robot_player.jl
+++ b/src/players/robot_player.jl
@@ -28,7 +28,7 @@ function choose_road_location(board::Board, players::AbstractVector{PlayerPublic
     return sample(candidates)
 end
 
-"""sample
+"""
     choose_building_location(board::Board, players::AbstractVector{PlayerPublicView}, 
     player::RobotPlayer, candidates::Vector{Tuple{Int, Int}}, building_type::Symbol
     )::Tuple{Int,Int}
@@ -161,7 +161,6 @@ function choose_next_action(board::Board, players::AbstractVector{PlayerPublicVi
     if name == :TradeWithBank
         resource_pair = sample(candidates)
         return ChosenAction(name, resource_pair...)
-
     end
     if name == :ProposeTrade
         # We add an additional random filter here to avoid extremely long, uninteresting trade negotiations between DefaultRobotPlayers.

--- a/src/players/robot_player.jl
+++ b/src/players/robot_player.jl
@@ -28,7 +28,7 @@ function choose_road_location(board::Board, players::AbstractVector{PlayerPublic
     return sample(candidates)
 end
 
-"""
+"""sample
     choose_building_location(board::Board, players::AbstractVector{PlayerPublicView}, 
     player::RobotPlayer, candidates::Vector{Tuple{Int, Int}}, building_type::Symbol
     )::Tuple{Int,Int}
@@ -158,6 +158,12 @@ function choose_next_action(board::Board, players::AbstractVector{PlayerPublicVi
             return ChosenAction(name, card)
         end            
     end
+    if name == :TradeWithBank
+        from_resource = sample(candidates)
+        to_resource = get_random_other_resource(from_resource)
+        return ChosenAction(name, from_resource, to_resource)
+
+    end
     if name == :ProposeTrade
         # We add an additional random filter here to avoid extremely long, uninteresting trade negotiations between DefaultRobotPlayers.
         if rand() > .8 && sum(values(player.player.resources)) > 0
@@ -165,10 +171,7 @@ function choose_next_action(board::Board, players::AbstractVector{PlayerPublicVi
             #sampled = random_sample_resources(player.player.resources, 1)
             #rand_resource_from = [sampled...]
             
-            rand_resource_to = [get_random_resource()]
-            while rand_resource_to[1] == rand_resource_from[1]
-                rand_resource_to = [get_random_resource()]
-            end
+            rand_resource_to = [get_random_other_resource(rand_resource_from)]
             return ChosenAction(name, rand_resource_from, rand_resource_to)
             #return (g, b, p) -> propose_trade_goods(b, g.players, p, rand_resource_from, rand_resource_to)
         end

--- a/src/players/robot_player.jl
+++ b/src/players/robot_player.jl
@@ -159,9 +159,8 @@ function choose_next_action(board::Board, players::AbstractVector{PlayerPublicVi
         end            
     end
     if name == :TradeWithBank
-        from_resource = sample(candidates)
-        to_resource = get_random_other_resource(from_resource)
-        return ChosenAction(name, from_resource, to_resource)
+        resource_pair = sample(candidates)
+        return ChosenAction(name, resource_pair...)
 
     end
     if name == :ProposeTrade
@@ -171,7 +170,7 @@ function choose_next_action(board::Board, players::AbstractVector{PlayerPublicVi
             #sampled = random_sample_resources(player.player.resources, 1)
             #rand_resource_from = [sampled...]
             
-            rand_resource_to = [get_random_other_resource(rand_resource_from)]
+            rand_resource_to = [get_random_other_resource(rand_resource_from[1])]
             return ChosenAction(name, rand_resource_from, rand_resource_to)
             #return (g, b, p) -> propose_trade_goods(b, g.players, p, rand_resource_from, rand_resource_to)
         end

--- a/src/random_helper.jl
+++ b/src/random_helper.jl
@@ -38,7 +38,7 @@ end
 function get_random_resource()
     return sample(collect(RESOURCES))
 end
-function get_random_other_resource(skip::Resource)
+function get_random_other_resource(skip::Symbol)
     resources = copy(RESOURCES)
     pop!(resources, skip)
     return sample(collect(resources))

--- a/src/random_helper.jl
+++ b/src/random_helper.jl
@@ -36,5 +36,10 @@ function get_random_empty_coord(board)
 end
 
 function get_random_resource()
-    return sample([RESOURCES...])
+    return sample(collect(RESOURCES))
+end
+function get_random_other_resource(skip::Resource)
+    resources = copy(RESOURCES)
+    pop!(resources, skip)
+    return sample(collect(resources))
 end

--- a/src/structs.jl
+++ b/src/structs.jl
@@ -115,6 +115,10 @@ struct ChosenAction
     ChosenAction(name::Symbol, args...) = new(name, args)
 end
 
+function Base.:(==)(a::ChosenAction, b::ChosenAction)
+    a.name == b.name && a.args == b.args
+end
+
 function Base.show(io::IO, a::ChosenAction)
     compact = get(io, :compact, false)
     if length(a.args) == 0

--- a/test/commands.data
+++ b/test/commands.data
@@ -1,0 +1,12 @@
+y
+sop
+sop
+p
+W
+bd
+f
+op
+cyan
+cyan
+W
+quit

--- a/test/helper.jl
+++ b/test/helper.jl
@@ -85,20 +85,25 @@ function test_automated_game(neverend, players, configs::Dict)
     end
 end
 
-function test_player_implementation(T::Type, configs) #where {T <: PlayerType}
+function test_player_implementation(T::Type, configs)
+    _test_player_implementation(T(:Blue, configs), configs)
+end
+
+function test_human_player_implementation(command_io, configs)
+    _test_player_implementation(HumanPlayer(Player(:Blue, configs), command_io), configs)
+end
+
+function _test_player_implementation(player::PlayerType, configs) #where {T <: PlayerType}
     private_players = [
-                       T(:Blue, configs)::PlayerType,
+            player,
                DefaultRobotPlayer(:Cyan, configs),
                DefaultRobotPlayer(:Yellow, configs),
                DefaultRobotPlayer(:Red, configs)
               ]
 
-    player = private_players[1]
     players = PlayerPublicView.(private_players)
-    game = Game(private_players, configs)
     board = Board(configs)::Board
     from_player = players[2]
-    #actions = Catan.ALL_ACTIONS
     actions = Set([PreAction(:BuyDevCard)])
 
     from_goods = [:Wood]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -784,7 +784,31 @@ end
     Catan.test_player_implementation(HumanPlayer, configs)
 end
 
-function run_tests(neverend = false)
+@testitem "trading_with_bank" setup=[global_test_setup] begin
+
+    player = DefaultRobotPlayer(:Blue, configs)
+    board = Board(configs)::Board
+
+    PlayerApi.give_resource!(player.player, :Brick)
+    PlayerApi.give_resource!(player.player, :Brick)
+    PlayerApi.add_port!(player.player, :Brick)
+    Catan.do_trade_with_bank(board, player, :Brick, :Stone)
+
+    @test player.player.ports[:Brick] == 2
+    @test player.player.resources[:Brick] == 0
+    @test player.player.resources[:Stone] == 1
+
+    PlayerApi.give_resource!(player.player, :Stone)
+    PlayerApi.give_resource!(player.player, :Stone)
+    PlayerApi.give_resource!(player.player, :Stone)
+    Catan.do_trade_with_bank(board, player, :Stone, :Wood)
+
+    @test player.player.resources[:Stone] == 0
+    @test player.player.resources[:Wood] == 1
+
+end
+
+function run_tests()
     ~ispath("data") && mkdir("data")
     io = open("_tmp_Configuration.toml", "w");
     write(io, """SAVE_GAME_TO_FILE = true
@@ -877,4 +901,4 @@ S,9,s
     close(io)
 end
 
-run_tests(false)
+run_tests()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -69,7 +69,7 @@ end
     #@show length(JET.get_reports(rep))
     #@show rep
     reports = JET.get_reports(rep)
-    max_num = 16
+    max_num = 18
     println("length(JET.get_reports(rep)) = $(length(reports)) / $max_num")
     @test length(reports) <= max_num
 end
@@ -330,7 +330,6 @@ end
 
     function test_resource_conservation(game, board)
         for r in RESOURCES
-            println(r)
             @test board.resources[r] + sum([p.player.resources[r] for p in game.players]) == 25
         end
     end
@@ -414,7 +413,6 @@ end
     push!(set, road1)
     push!(set, road2)
     push!(set, road2)
-    println(set)
     @test length(set) == 1
 end
 
@@ -780,8 +778,25 @@ end
     Catan.test_player_implementation(DefaultRobotPlayer, configs)
 end
 
-@testitem "human_player_implementation" setup=[global_test_setup] tags=[:broken] begin
-    Catan.test_player_implementation(HumanPlayer, configs)
+@testitem "human_player_implementation" setup=[global_test_setup] begin
+    commands = open("data/commands.txt", "r")
+    Catan.test_human_player_implementation(commands, configs)
+    close(commands)
+end
+
+@testitem "human_player_parse_action" setup=[global_test_setup] begin
+    results_dict = Dict([
+        "bs sop" => ChosenAction(:ConstructSettlement, ((5,7),)),
+        "bc sop" => ChosenAction(:ConstructCity, ((5,7),)),
+        "br op" => ChosenAction(:ConstructRoad, ((4,8),(5,7),true,)),
+        "pt 2 w w g g" => ChosenAction(:ProposeTrade, ([:Wood, :Wood], [:Grain, :Grain],)),
+        "bd" => ChosenAction(:BuyDevCard),
+        "pd knight" => ChosenAction(:PlayDevCard, :Knight),
+        "tb w b" => ChosenAction(:TradeWithBank, (:Wood, :Brick))
+    ])
+    for (human_resp, act) in results_dict
+        @test Catan._parse_action_from_response(human_resp) == act
+    end
 end
 
 @testitem "trading_with_bank" setup=[global_test_setup] begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -779,7 +779,7 @@ end
 end
 
 @testitem "human_player_implementation" setup=[global_test_setup] begin
-    commands = open("commands.txt", "r")
+    commands = open("commands.data", "r")
     Catan.test_human_player_implementation(commands, configs)
     close(commands)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -779,7 +779,7 @@ end
 end
 
 @testitem "human_player_implementation" setup=[global_test_setup] begin
-    commands = open("data/commands.txt", "r")
+    commands = open("commands.txt", "r")
     Catan.test_human_player_implementation(commands, configs)
     close(commands)
 end


### PR DESCRIPTION
Although the port-based exchange rates were implemented and tested a long time ago, we never propagated this to a proper action that players can use.  We introduce that here, with `:TradeWithBank` action.